### PR TITLE
missing 'import re'

### DIFF
--- a/clsdocs.py
+++ b/clsdocs.py
@@ -35,6 +35,7 @@ import sublime_plugin
 import urllib2
 from bs4 import BeautifulSoup
 import webbrowser
+import re
 
 def request(var):
     var = "http://clojuredocs.org/search?q=%s" % var


### PR DESCRIPTION
my copy was misfiring on ctl-shift-c complaining about missing re in the ST error console.
I saw it was imported and subsequently wasn't so introduced it

It seems to work now.
